### PR TITLE
Configurable control character for most modules

### DIFF
--- a/src/mod_admin.c
+++ b/src/mod_admin.c
@@ -14,7 +14,7 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_init  = admin_init,
 	.on_cmd   = &admin_cmd,
 	.commands = DEFINE_CMDS (
-		[FORCE_JOIN] = "\\fjoin"
+		[FORCE_JOIN] = CONTROL_CHAR "fjoin"
 	)
 };
 

--- a/src/mod_alias.c
+++ b/src/mod_alias.c
@@ -20,9 +20,9 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_cmd   = &alias_cmd,
 	.on_init  = &alias_init,
 	.commands = DEFINE_CMDS (
-		[ALIAS_ADD]  = "\\alias",
-		[ALIAS_DEL]  = "\\unalias \\delalias \\rmalias",
-		[ALIAS_LIST] = "\\lsalias \\lsa \\listalias \\listaliases"
+		[ALIAS_ADD]  = CONTROL_CHAR "alias",
+		[ALIAS_DEL]  = CONTROL_CHAR "unalias " CONTROL_CHAR "delalias " CONTROL_CHAR "rmalias",
+		[ALIAS_LIST] = CONTROL_CHAR "lsalias " CONTROL_CHAR "lsa " CONTROL_CHAR "listalias " CONTROL_CHAR "listaliases"
 	)
 };
 
@@ -134,9 +134,9 @@ static void alias_cmd(const char* chan, const char* name, const char* arg, int c
 	return;
 
 usage_add:
-	ctx->send_msg(chan, "%s: Usage: \\alias <key> <text>", name); return;
+	ctx->send_msg(chan, "%s: Usage: "CONTROL_CHAR"alias <key> <text>", name); return;
 usage_del:
-	ctx->send_msg(chan, "%s: Usage: \\unalias <key>", name); return;
+	ctx->send_msg(chan, "%s: Usage: "CONTROL_CHAR"unalias <key>", name); return;
 }
 
 static void alias_msg(const char* chan, const char* name, const char* msg){

--- a/src/mod_chans.c
+++ b/src/mod_chans.c
@@ -21,8 +21,8 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_save    = &chans_save,
 	.on_connect = &chans_connect,
 	.commands   = DEFINE_CMDS (
-		[CHAN_JOIN]  = "\\join",
-		[CHAN_LEAVE] = "\\leave \\part"
+		[CHAN_JOIN]  = CONTROL_CHAR"join",
+		[CHAN_LEAVE] = CONTROL_CHAR"leave " CONTROL_CHAR"part"
 	)
 };
 

--- a/src/mod_help.c
+++ b/src/mod_help.c
@@ -16,7 +16,7 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_init  = help_init,
 	.on_cmd   = &help_cmd,
 	.commands = DEFINE_CMDS (
-		[CMD_HELP] = "\\help"
+		[CMD_HELP] = CONTROL_CHAR"help"
 	)
 };
 

--- a/src/mod_hmh.c
+++ b/src/mod_hmh.c
@@ -18,8 +18,8 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_cmd   = &hmh_cmd,
 	.on_init  = &hmh_init,
 	.commands = DEFINE_CMDS (
-		[CMD_SCHEDULE] = "!sched \\sched \\schedule",
-		[CMD_TIME]     = "!tm    \\tm    \\time"
+		[CMD_SCHEDULE] = CONTROL_CHAR"sched " CONTROL_CHAR"schedule",
+		[CMD_TIME]     = CONTROL_CHAR"tm "CONTROL_CHAR"time"
 	)
 };
 

--- a/src/mod_meta.c
+++ b/src/mod_meta.c
@@ -31,10 +31,10 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_init  = &meta_init,
 	.on_join  = &meta_join,
 	.commands = DEFINE_CMDS (
-		[CMD_MODULES]  = "\\m     \\modules",
-		[CMD_MOD_ON]   = "\\mon   \\modon",
-		[CMD_MOD_OFF]  = "\\moff  \\modoff",
-		[CMD_MOD_INFO] = "\\minfo \\modinfo"
+		[CMD_MODULES]  = CONTROL_CHAR"m "     CONTROL_CHAR"modules",
+		[CMD_MOD_ON]   = CONTROL_CHAR"mon "   CONTROL_CHAR"modon",
+		[CMD_MOD_OFF]  = CONTROL_CHAR"moff "  CONTROL_CHAR"modoff",
+		[CMD_MOD_INFO] = CONTROL_CHAR"minfo " CONTROL_CHAR"modinfo"
 	)
 };
 

--- a/src/mod_quotes.c
+++ b/src/mod_quotes.c
@@ -22,13 +22,13 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_join  = &quotes_join,
 	.on_save  = &quotes_save,
 	.commands = DEFINE_CMDS (
-		[GET_QUOTE]     = "\\q    \\quote",
-		[ADD_QUOTE]     = "\\qadd \\q+",
-		[DEL_QUOTE]     = "\\qdel \\q-",
-		[FIX_QUOTE]     = "\\qfix \\qmv",
-		[FIX_TIME]      = "\\qft  \\qfixtime",
-		[LIST_QUOTES]   = "\\ql   \\qlist",
-		[SEARCH_QUOTES] = "\\qs   \\qsearch \\qfind \\qgrep"
+		[GET_QUOTE]     = CONTROL_CHAR"q    "CONTROL_CHAR"quote",
+		[ADD_QUOTE]     = CONTROL_CHAR"qadd "CONTROL_CHAR"q+",
+		[DEL_QUOTE]     = CONTROL_CHAR"qdel "CONTROL_CHAR"q-",
+		[FIX_QUOTE]     = CONTROL_CHAR"qfix "CONTROL_CHAR"qmv",
+		[FIX_TIME]      = CONTROL_CHAR"qft  "CONTROL_CHAR"qfixtime",
+		[LIST_QUOTES]   = CONTROL_CHAR"ql   "CONTROL_CHAR"qlist",
+		[SEARCH_QUOTES] = CONTROL_CHAR"qs   "CONTROL_CHAR"qsearch " CONTROL_CHAR"qfind " CONTROL_CHAR"qgrep"
 	)
 };
 

--- a/src/mod_twitch.c
+++ b/src/mod_twitch.c
@@ -21,7 +21,7 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_tick  = &twitch_tick,
 	.on_save  = &twitch_save,
 	.commands = DEFINE_CMDS (
-		[FOLLOW_NOTIFY] = "\\fnotify"
+		[FOLLOW_NOTIFY] = CONTROL_CHAR"fnotify"
 	)
 };
 

--- a/src/mod_whitelist.c
+++ b/src/mod_whitelist.c
@@ -20,10 +20,10 @@ const IRCModuleCtx irc_mod_ctx = {
 	.on_mod_msg = &whitelist_mod_msg,
 	.on_save    = &whitelist_save,
 	.commands   = DEFINE_CMDS (
-		[WL_CHECK_SELF]  = "\\wl    \\wlcheckme \\amiwhitelisted",
-		[WL_CHECK_OTHER] = "\\iswl  \\wlcheck",
-		[WL_ADD]         = "\\wladd \\wl+",
-		[WL_DEL]         = "\\wldel \\wl-"
+		[WL_CHECK_SELF]  = CONTROL_CHAR"wl    "CONTROL_CHAR"wlcheckme "CONTROL_CHAR"amiwhitelisted",
+		[WL_CHECK_OTHER] = CONTROL_CHAR"iswl  "CONTROL_CHAR"wlcheck",
+		[WL_ADD]         = CONTROL_CHAR"wladd "CONTROL_CHAR"wl+",
+		[WL_DEL]         = CONTROL_CHAR"wldel "CONTROL_CHAR"wl-"
 	)
 };
 

--- a/src/module.h
+++ b/src/module.h
@@ -92,4 +92,6 @@ typedef struct IRCModMsg_ {
 	0\
 }
 
+#define CONTROL_CHAR "!"
+
 #endif


### PR DESCRIPTION
Simple define in src\modules.h of a string to be used as the prefix for most commands via automatic preprocessor string concatenation. Added it to the command definitions in most of the current modules, replacing "\". Did not apply to `mod_karma.c` or `mod_markov.cpp`. 
