### PR TITLE
Expand mod_alias to support alias permissions, multiple triggers, /me aliases

### DIFF
--- a/src/mod_alias.c
+++ b/src/mod_alias.c
@@ -29,21 +29,206 @@ const IRCModuleCtx irc_mod_ctx = {
 
 static const IRCCoreCtx* ctx;
 
+enum {
+    AP_NORMAL = 0,
+    AP_WHITELISTED,
+    AP_ADMINONLY,
+       
+    AP_COUNT,
+};
+
+char* alias_permission_strs[] = {
+    "NORMAL",
+    "WLIST",
+    "ADMIN",
+};
+
+typedef struct {
+    int permission;
+    char** keys;
+    char* msg;
+} Alias;
+
 //TODO: aliases should be per-channel
 static char** alias_keys;
-static char** alias_vals;
+static int* alias_val_offsets;
+
+static Alias* alias_pool;
+
+static Alias* alias_get_i(int ikey){
+    int ival = alias_val_offsets[ikey];
+    return alias_pool + ival;
+}
+
+// Adds a totally new alias, allocating one from the pool and setting up its initial values
+static void alias_new(char* key, char* msg, int perm) {
+    fprintf(stderr, "New alias: [%s] = [%s] (Access level %s)\n", key, msg, alias_permission_strs[perm]);
+    Alias value = {
+        .permission = perm,
+        .keys       = NULL,
+        .msg        = msg,
+    };
+    sb_push(alias_keys, key);
+    sb_push(value.keys, key);
+    sb_push(alias_pool, value);
+    sb_push(alias_val_offsets, sb_count(alias_pool) - 1);
+}
+
+// Removes an alias from the value list, freeing up its spot in the pool
+static void alias_delete(int ikey) {
+    int ival = alias_val_offsets[ikey];
+    Alias* value = alias_pool + ival;
+    if (sb_count(value->keys) == 0) {
+        sb_free(value->keys);
+        free(value->msg);
+    }
+    // Else someone still has a reference to us
+    else return;
+
+    sb_erase(alias_pool, ival);
+}
+
+// Notifies an atlas that the key at alias_keys[ikey] is no longer pointing to it
+// Possibly deleting the atlas if that was the last reference to it
+static void alias_remove_reference(int ikey) {
+    Alias* value = alias_get_i(ikey);
+    //Iterate over alias's stored keys to check that this key points to it
+    for (int ivalkey = 0; ivalkey < sb_count(value->keys); ++ivalkey) {
+        if (strcmp(alias_keys[ikey], value->keys[ivalkey]) == 0) {
+            // Remove this key from this alias's key list
+            sb_erase(value->keys, ivalkey);
+            break;
+        }
+    }
+    if (sb_count(value->keys) == 0) {
+        alias_delete(ikey);
+    }
+}
+
+// Adds another key that maps to the same value as oldkey
+static void alias_add_reference(int i_oldkey, char* newkey) {
+    Alias* value = alias_get_i(i_oldkey);
+    int ival = value - alias_pool;
+    sb_push(value->keys, newkey);
+    sb_push(alias_keys, newkey);
+    sb_push(alias_val_offsets, ival);
+}
+
+// Updates the msg and/or permission flag of an alias.
+// If update_other_references is false, and other keys point to this alias,
+//   we'll make a new alias struct and point the key at that instead.
+static void alias_update(int ikey, char* key, char* msg, int perm, bool update_other_references)
+{
+    if (strcmp(alias_keys[ikey], key) != 0) return;
+    Alias* value = alias_get_i(ikey);
+
+    if (update_other_references || sb_count(value->keys) == 0) {
+        if (msg != NULL) { value->msg = msg; }
+        value->permission = perm;
+    }
+    else {
+        // Can't use the existing alias instance, since someone else points to us
+        //   and we don't want them to update unless specifically asked to
+        alias_remove_reference(ikey);
+
+        Alias value = {
+            .permission = perm,
+            .keys       = NULL,
+            .msg        = msg,
+        };
+        sb_push(alias_pool, value);
+        alias_val_offsets[ikey] = sb_count(alias_pool) - 1;
+    }
+}
+
+static void alias_add(char* key, char* msg, int perm)
+{
+    //TODO(chronister): I think this can be simplified down into alias_update
+    //   by just creating the alias if it isn't found in that function
+    // But I need to check use cases first
+    bool found = false;
+    for(int i = 0; i < sb_count(alias_keys); ++i){
+        if(strcmp(key, alias_keys[i]) == 0){
+            alias_update(i, key, msg, perm, false);
+            found = true;
+        }
+    }
+
+    if(!found){
+        alias_new(strdup(key), msg, perm);
+    }
+}
 
 static bool alias_init(const IRCCoreCtx* _ctx){
 	ctx = _ctx;
 	FILE* f = fopen(ctx->get_datafile(), "rb");
 
-	char *key, *val;
+    bool got_alias = false;
+	do {
+        size_t fptr = ftell(f);
+        char *keystr, *permstr, *msg;
+        int perm = -1;
+        got_alias = false; // Guilty until proven innocent
 
-	while(fscanf(f, "%ms %m[^\n]", &key, &val) == 2){
-		fprintf(stderr, "Got alias: [%s] = [%s]\n", key, val);
-		sb_push(alias_keys, key);
-		sb_push(alias_vals, val);
-	}
+        bool got_keys = fscanf(f, " [%m[^]]]", &keystr) == 1;
+        if (got_keys) {
+            int c;
+            while(1) {
+                c = fgetc(f);
+                if (c == ' ')       continue;
+                else if (c == ']')  continue;
+                else if (c == ':')  break;
+                else break;
+            }
+            
+            if (c == ':') {
+                got_alias = fscanf(f, "%ms %m[^\n]", &permstr, &msg) == 2;
+                
+                if      (strcmp(permstr, alias_permission_strs[AP_NORMAL]) == 0)        perm = AP_NORMAL;
+                else if (strcmp(permstr, alias_permission_strs[AP_WHITELISTED]) == 0)   perm = AP_WHITELISTED;
+                else if (strcmp(permstr, alias_permission_strs[AP_ADMINONLY]) == 0)     perm = AP_ADMINONLY;
+
+                free(permstr);
+
+                if (perm == -1) { 
+                    got_alias = false; 
+                    free(keystr);
+                    free(msg);
+                }
+            }
+            else {
+                free(keystr);
+            }
+        }
+
+        char** keys = NULL;
+
+        if (got_alias) {
+            char* keystart = keystr;
+            for (char* keycur = keystr + 1; *(keycur-1); ++keycur) {
+                if ((isspace(*keycur) || *keycur == 0) && !isspace(*(keycur - 1)))
+                    sb_push(keys, strndup(keystart, keycur - keystart));
+                else if (!isspace(*keycur) && isspace(*(keycur - 1)))
+                    keystart = keycur;
+            }
+        }
+
+        if (!got_alias) {
+            // Might be an old-style alias declaration
+            fseek(f, fptr, SEEK_SET);
+            got_alias = fscanf(f, "%ms %m[^\n]", &keystr, &msg) == 2;
+            sb_push(keys, keystr);
+            perm = AP_NORMAL;
+        }
+
+        if (got_alias && keys != NULL) {
+            alias_add(keys[0], msg, perm);
+            int ikey = sb_count(keys) - 1;
+            for (int i = 1; i < sb_count(keys); ++i) {
+                alias_add_reference(ikey, keys[i]);
+            }
+        }
+	} while(got_alias);
 		
 	return true;
 }
@@ -70,21 +255,29 @@ static void alias_cmd(const char* chan, const char* name, const char* arg, int c
 			char* key = strndupa(arg, space - arg);
 			for(char* k = key; *k; ++k) *k = tolower(*k);
 
-			bool found = false;
-			for(int i = 0; i < sb_count(alias_keys); ++i){
-				if(strcmp(key, alias_keys[i]) == 0){
-					free(alias_vals[i]);
-					alias_vals[i] = strdup(space+1);
-					found = true;
-				}
-			}
+            if (strncmp(space+1, "->", 2) == 0) {
+                // Aliasing new key to existing command
+                char* otherkey;
+                sscanf(space + 3, " %ms", &otherkey);
 
-			if(!found){
-				sb_push(alias_keys, strdup(key));
-				sb_push(alias_vals, strdup(space+1));
-			}
+                bool found = false;
+                for(int i = 0; i < sb_count(alias_keys); ++i){
+                    if(strcmp(otherkey, alias_keys[i]) == 0){
+                        found = true;
+                        alias_add_reference(i, strdup(key));
+                        ctx->send_msg(chan, "%s: Alias %s set.", name, key);
+                    }
+                }
+                if (!found) {
+                    ctx->send_msg(chan, "%s: Can't alias %s as %s is not defined.", name, key, otherkey);
+                    free(otherkey);
+                }
+            }
+            else {
+                alias_add(strdup(key), strdup(space+1), AP_NORMAL);
+                ctx->send_msg(chan, "%s: Alias %s set.", name, key);
+            }
 
-			ctx->send_msg(chan, "%s: Alias %s set.", name, key);
 		} break;
 
 		case ALIAS_DEL: {
@@ -95,11 +288,9 @@ static void alias_cmd(const char* chan, const char* name, const char* arg, int c
 				if(strcasecmp(arg, alias_keys[i]) == 0){
 					found = true;
 
-					free(alias_keys[i]);
-					sb_erase(alias_keys, i);
-					
-					free(alias_vals[i]);
-					sb_erase(alias_vals, i);
+                    alias_remove_reference(i);
+                    sb_erase(alias_keys, i);
+                    sb_erase(alias_val_offsets, i);
 
 					ctx->send_msg(chan, "%s: Removed alias %s.\n", name, arg);
 					break;
@@ -143,7 +334,7 @@ static void alias_cmd(const char* chan, const char* name, const char* arg, int c
 			for(int i = 0; i < sb_count(alias_keys); ++i){
 				if(strcmp(key, alias_keys[i]) == 0){
 					found = true;
-                    alias = alias_vals + i;
+                    alias = alias_get_i(i);
 				}
 			}
 
@@ -214,7 +405,21 @@ static void alias_msg(const char* chan, const char* name, const char* msg){
 	size_t name_len = strlen(name);
 	char* msg_buf = NULL;
 
-	for(const char* str = alias_vals[index]; *str; ++str){
+    Alias* value = alias_get_i(index);
+	bool has_cmd_perms = (value->permission == AP_NORMAL) || strcasecmp(chan+1, name) == 0;
+	if(!has_cmd_perms){
+        if (value->permission == AP_WHITELISTED)
+            MOD_MSG(ctx, "check_whitelist", name, &whitelist_cb, &has_cmd_perms);
+        else if (value->permission == AP_ADMINONLY)
+            MOD_MSG(ctx, "check_admin", name, &whitelist_cb, &has_cmd_perms);
+        else {
+            // Some kind of weird unknown permission type. Assume normal access.
+            has_cmd_perms = true;
+        }
+	}
+	if(!has_cmd_perms) return;
+
+	for(const char* str = value->msg; *str; ++str){
 		if(*str == '%' && *(str + 1) == 't'){
 			memcpy(sb_add(msg_buf, name_len), name, name_len);
 			++str;
@@ -242,8 +447,20 @@ static void alias_msg(const char* chan, const char* name, const char* msg){
 }
 
 static bool alias_save(FILE* file){
-	for(int i = 0; i < sb_count(alias_keys); ++i){
-		fprintf(file, "%s\t%s\n", alias_keys[i], alias_vals[i]);
+	for(int i = 0; i < sb_count(alias_pool); ++i){
+        Alias* alias = alias_pool + i;
+        fputc('[', file);
+        for (int ikey = 0; ikey < sb_count(alias->keys); ++ikey) {
+            fputs(alias->keys[ikey], file); 
+            fputc(' ', file);
+        }
+        fputc(']', file);
+        bool perm_valid = (alias->permission >= 0 && alias->permission <= AP_COUNT);
+        if (perm_valid) {
+            fputc(':', file);
+            fputs(alias_permission_strs[alias->permission], file);
+        }
+        fprintf(file, " %s\n", alias->msg);
 	}
 	return true;
 }


### PR DESCRIPTION
mod_alias has been expanded to more complicated alias handling. Alias data format has been changed. Instead of two arrays:

```
char** alias_keys;
char** alias_values;
```

There are now three:

```
char** alias_keys;
int* alias_val_offsets;
Alias* alias_pool;
```

When a new alias is created, it is pushed onto the alias pool. The val_offset corresponding to an alias key specifies which value in the alias_pool to reference -- it's not a direct pointer, as the pointers to Aliases in the alias_pool are unstable (stretchy_buffer). This way multiple alias_keys can point to the same Alias in the pool.

Several new functions have been added to help deal with manipulating these structures. 
- `alias_new` allocates an alias from the pool and initializes the fields of the alias, as well as pushing on a new key at the same time.
- `alias_delete` will attempt to delete an alias from the alias_pool, but will not do so if the alias still lists at least one key in its `keys` field. 
- `alias_remove_reference` will remove a key from an Alias's `keys` list, and if this was the last reference to the Alias, delete it by calling `alias_delete`.
- `alias_update` changes the `msg` and `perm` values of an Alias, allowing you to specify whether it should create an entirely new Alias if doing so would change the values of other Aliases. The current !alias handling code always opts to preserve the values of other references, and will thus always create a new Alias if there are other references.
- `alias_add_reference` specifies that an Alias has a new key referencing it, `newkey`. If `newkey` already pointed to an alias, it removes that reference before adding a reference to the new target Alias.
- `alias_add` attempts to create a new alias with the given key, message, and permission unless the given key already exists, in which case it calls `alias_update` with the provided information.

Parsing of the log file on init has been expanded to support a new data format, which is written out on save. The _parser_ is backwards-compatible with the old alias format, though the format is not. The old format:

```
 key Some message here.
```

The new format:

```
[key1 key2 key3 ]:PERMISSION Some message here.
```

PERMISSION must be specified and a valid permission string (current NORMAL, WLIST, or ADMIN), or it will drop to old-format parsing and read incorrect values for the keys. A future patch could address this by making the permission string optional, potentially at the expensive of slightly more verbose parsing.

The IRC-level command interface has not changed significantly, with two exceptions:
1. `!alias` now special cases a certain string format which specifies that key1 should be a reference to key2:
   
   !alias key1 -> key2
2. `!chaliasmod`, which changes the permission of an alias to one of "normal", "wlist", or "admin".
   
   !chamod key wlist

Finally, alias messages that being with the string "/me" will automatically be converted into CTCP ACTION messages upon sending. If a future revision of the core bot adds support for CTCP messages, this module should be updated to use that.
